### PR TITLE
Adapter request format

### DIFF
--- a/ripozo/adapters/base.py
+++ b/ripozo/adapters/base.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from abc import ABCMeta, abstractproperty
+from warnings import warn
 
 from ripozo.utilities import join_url_parts
 
@@ -97,9 +98,29 @@ class AdapterBase(object):
             http response code
         :rtype: tuple
         """
+        warn('format_exception will be an abstract method in release 2.0.0. '
+             'You will need to implement this method in your adapter.', DeprecationWarning)
         status_code = getattr(exc, 'status_code', 500)
         body = json.dumps(dict(status=status_code, message=six.text_type(exc)))
         return body, cls.formats[0], status_code
+
+    @classmethod
+    def format_request(cls, request):
+        """
+        Takes a request and appropriately reformats
+        the request.  For example, jsonAPI requires a
+        specific request format that must be transformed
+        to work with ripozo.  For this base implementation
+        it simply returns the request without any additional
+        formating.
+
+        :param RequestContainer request: The request to reformat.
+        :return: The formatted request.
+        :rtype: RequestContainer
+        """
+        warn('format_request will be an abstractmethod in release 2.0. '
+             'You will need to implement this method in your adapter', DeprecationWarning)
+        return request
 
     @property
     def status_code(self):

--- a/ripozo/adapters/basic_json.py
+++ b/ripozo/adapters/basic_json.py
@@ -62,7 +62,8 @@ class BasicJSONAdapter(AdapterBase):
     def _append_relationships_to_list(rel_dict, relationships):
         """
         Dumps the relationship resources provided into
-        a json ready list of dictionaries.
+        a json ready list of dictionaries.  Side effect
+        of updating the dictionary with the relationships
 
         :param dict rel_dict:
         :param list relationships:

--- a/ripozo/adapters/basic_json.py
+++ b/ripozo/adapters/basic_json.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 from ripozo.adapters import AdapterBase
 
 import json
+import six
 
 _CONTENT_TYPE = 'application/json'
 
@@ -76,3 +77,26 @@ class BasicJSONAdapter(AdapterBase):
                     rel_dict[name].append(res.properties)
                 continue
             rel_dict[name].append(resource.properties)
+
+    @classmethod
+    def format_exception(cls, exc):
+        """
+        Takes an exception and appropriately formats
+        the response.  By default it just returns a json dump
+        of the status code and the exception message.
+        Any exception that does not have a status_code attribute
+        will have a status_code of 500.
+
+        :param Exception exc: The exception to format.
+        :return: A tuple containing: response body, format,
+            http response code
+        :rtype: tuple
+        """
+        status_code = getattr(exc, 'status_code', 500)
+        body = json.dumps(dict(status=status_code, message=six.text_type(exc)))
+        return body, cls.formats[0], status_code
+
+    @classmethod
+    def format_request(cls, request):
+        """Does nothing with request"""
+        return request

--- a/ripozo/adapters/basic_json.py
+++ b/ripozo/adapters/basic_json.py
@@ -98,5 +98,10 @@ class BasicJSONAdapter(AdapterBase):
 
     @classmethod
     def format_request(cls, request):
-        """Does nothing with request"""
+        """
+        Simply returns request
+
+        :param RequestContainer request: The request to handler
+        :rtype: RequestContainer
+        """
         return request

--- a/ripozo/adapters/hal.py
+++ b/ripozo/adapters/hal.py
@@ -114,5 +114,10 @@ class HalAdapter(AdapterBase):
 
     @classmethod
     def format_request(cls, request):
-        """Does nothing with request, simply returns it"""
+        """
+        Simply returns request
+
+        :param RequestContainer request: The request to handler
+        :rtype: RequestContainer
+        """
         return request

--- a/ripozo/adapters/hal.py
+++ b/ripozo/adapters/hal.py
@@ -111,3 +111,8 @@ class HalAdapter(AdapterBase):
         body = json.dumps(dict(status=status_code, message=six.text_type(exc),
                                _embedded={}, _links={}))
         return body, cls.formats[0], status_code
+
+    @classmethod
+    def format_request(cls, request):
+        """Does nothing with request, simply returns it"""
+        return request

--- a/ripozo/adapters/siren.py
+++ b/ripozo/adapters/siren.py
@@ -163,5 +163,10 @@ class SirenAdapter(AdapterBase):
 
     @classmethod
     def format_request(cls, request):
-        """Does nothing with request, simply return request"""
+        """
+        Simply returns request
+
+        :param RequestContainer request: The request to handler
+        :rtype: RequestContainer
+        """
         return request

--- a/ripozo/adapters/siren.py
+++ b/ripozo/adapters/siren.py
@@ -160,3 +160,8 @@ class SirenAdapter(AdapterBase):
                 'actions': [], 'entities': [], 'links': [],
                 'properties': dict(status=status_code, message=six.text_type(exc))}
         return json.dumps(body), cls.formats[0], status_code
+
+    @classmethod
+    def format_request(cls, request):
+        """Does nothing with request, simply return request"""
+        return request

--- a/ripozo/dispatch_base.py
+++ b/ripozo/dispatch_base.py
@@ -185,7 +185,7 @@ class DispatcherBase(object):
         """
         pass
 
-    def dispatch(self, endpoint_func, accepted_mimetypes, *args, **kwargs):
+    def dispatch(self, endpoint_func, accepted_mimetypes, request, *args, **kwargs):
         """
         A helper to dispatch the endpoint_func, get the ResourceBase
         subclass instance, get the appropriate AdapterBase subclass
@@ -196,6 +196,7 @@ class DispatcherBase(object):
         :param list accepted_mimetypes: The mime types accepted by
             the client.  If none of the mimetypes provided are
             available the default adapter will be used.
+        :param RequestContainer request: The request object
         :param list args: a list of args that wll be passed
             to the endpoint_func
         :param dict kwargs: a dictionary of keyword args to
@@ -206,8 +207,9 @@ class DispatcherBase(object):
         """
         _logger.info('Dispatching request to endpoint function: %s with args:'
                      ' %s and kwargs:%s', endpoint_func, args, kwargs)
-        result = endpoint_func(*args, **kwargs)
         adapter_class = self.get_adapter_for_type(accepted_mimetypes)
+        request = adapter_class.format_request(request)
+        result = endpoint_func(request, *args, **kwargs)
         _logger.info('Using adapter %s to format response for format'
                      ' type %s', adapter_class, accepted_mimetypes)
         adapter = adapter_class(result, base_url=self.base_url)

--- a/ripozo_tests/unit/dispatch/adapters/base.py
+++ b/ripozo_tests/unit/dispatch/adapters/base.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import unittest2
 import json
 
+from ripozo import RequestContainer
 from ripozo.adapters.base import AdapterBase
 from ripozo.resources.relationships import Relationship, ListRelationship
 from ripozo.resources.resource_base import ResourceBase
@@ -92,3 +93,9 @@ class TestAdapterBase(unittest2.TestCase):
         self.assertEqual(TestAdapter.formats[0], content_type)
         self.assertEqual(status_code, 458)
         self.assertEqual(data['message'], 'blah blah')
+
+    def test_format_request(self):
+        """Dumb test for format_request"""
+        request = RequestContainer()
+        response = TestAdapter.format_request(request)
+        self.assertIs(response, request)

--- a/ripozo_tests/unit/dispatch/adapters/boring_json.py
+++ b/ripozo_tests/unit/dispatch/adapters/boring_json.py
@@ -9,6 +9,7 @@ import six
 import unittest2
 
 from ripozo.adapters import BasicJSONAdapter
+from ripozo.exceptions import RestException
 from ripozo.resources.request import RequestContainer
 from ripozo_tests.helpers.hello_world_viewset import get_refreshed_helloworld_viewset
 
@@ -41,3 +42,20 @@ class TestBoringJSONAdapter(unittest2.TestCase):
     def test_content_header(self):
         adapter = BasicJSONAdapter(None)
         self.assertEqual(adapter.extra_headers, {'Content-Type': 'application/json'})
+
+    def test_format_exception(self):
+        """
+        Tests the format_exception class method.
+        """
+        exc = RestException('blah blah', status_code=458)
+        json_dump, content_type, status_code = BasicJSONAdapter.format_exception(exc)
+        data = json.loads(json_dump)
+        self.assertEqual(BasicJSONAdapter.formats[0], content_type)
+        self.assertEqual(status_code, 458)
+        self.assertEqual(data['message'], 'blah blah')
+
+    def test_format_request(self):
+        """Dumb test for format_request"""
+        request = RequestContainer()
+        response = BasicJSONAdapter.format_request(request)
+        self.assertIs(response, request)

--- a/ripozo_tests/unit/dispatch/adapters/boring_json.py
+++ b/ripozo_tests/unit/dispatch/adapters/boring_json.py
@@ -8,6 +8,7 @@ import json
 import six
 import unittest2
 
+from ripozo import ResourceBase
 from ripozo.adapters import BasicJSONAdapter
 from ripozo.exceptions import RestException
 from ripozo.resources.request import RequestContainer
@@ -59,3 +60,29 @@ class TestBoringJSONAdapter(unittest2.TestCase):
         request = RequestContainer()
         response = BasicJSONAdapter.format_request(request)
         self.assertIs(response, request)
+
+    def test_append_relationships_to_list_list_relationship(self):
+        """
+        Tests whether the relationships are appropriately
+        added to the response
+        """
+        class MyResource(ResourceBase):
+            pass
+
+        relationship_list = [MyResource(properties=dict(id=1)), MyResource(properties=dict(id=2))]
+        relationships = [(relationship_list, 'name', True)]
+        rel_dict = {}
+        BasicJSONAdapter._append_relationships_to_list(rel_dict, relationships)
+        self.assertDictEqual(dict(name=[dict(id=1), dict(id=2)]), rel_dict)
+
+    def test_append_relationships_to_list_single_relationship(self):
+        """
+        Ensures that a Relationship (not ListRelationship) is properly added
+        """
+        class MyResource(ResourceBase):
+            pass
+
+        relationships = [(MyResource(properties=dict(id=1)), 'name', True)]
+        rel_dict = {}
+        BasicJSONAdapter._append_relationships_to_list(rel_dict, relationships)
+        self.assertDictEqual(dict(name=[dict(id=1)]), rel_dict)

--- a/ripozo_tests/unit/dispatch/adapters/hal.py
+++ b/ripozo_tests/unit/dispatch/adapters/hal.py
@@ -154,3 +154,9 @@ class TestHalAdapter(unittest2.TestCase):
         self.assertIn('_embedded', data)
         self.assertIn('_links', data)
         self.assertEqual(data['message'], 'blah blah')
+
+    def test_format_request(self):
+        """Dumb test for format_request"""
+        request = RequestContainer()
+        response = HalAdapter.format_request(request)
+        self.assertIs(response, request)

--- a/ripozo_tests/unit/dispatch/adapters/siren.py
+++ b/ripozo_tests/unit/dispatch/adapters/siren.py
@@ -242,3 +242,9 @@ class TestSirenAdapter(TestAdapterBase):
         adapter = SirenAdapter(mock.MagicMock())
         fields_found = adapter.generate_fields_for_endpoint_funct(endpoint_func)
         self.assertListEqual(fields_found, [])
+
+    def test_format_request(self):
+        """Dumb test for format_request"""
+        request = RequestContainer()
+        response = SirenAdapter.format_request(request)
+        self.assertIs(response, request)

--- a/ripozo_tests/unit/dispatch/dispatch_base.py
+++ b/ripozo_tests/unit/dispatch/dispatch_base.py
@@ -40,14 +40,13 @@ class TestDispatchBase(unittest2.TestCase):
 
     def test_dispatch(self):
         endpoint_func = MagicMock()
-        self.assertRaises(TypeError, self.dispatcher.dispatch, endpoint_func, 'fake')
-        self.assertEqual(endpoint_func.call_count, 1)
+        request = mock.MagicMock()
         adapter = MagicMock()
         adapter.formats = ['fake']
         self.dispatcher.register_adapters(adapter)
-        self.dispatcher.dispatch(endpoint_func, 'fake')
+        self.dispatcher.dispatch(endpoint_func, 'fake', request)
         self.assertEqual(adapter.call_count, 1)
-        self.assertEqual(endpoint_func.call_count, 2)
+        self.assertEqual(endpoint_func.call_count, 1)
 
     def test_register_adapters(self):
         """Tests whether adapters are properly registered"""


### PR DESCRIPTION
Fixes #37 while still keeping it backwards compatible.  Warnings raised when an adapter does not implement the soon to be abstract methods of format_exception and format_request