### PR TITLE
Popping relationship properties

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,16 +4,17 @@ Changelog
 1.x Releases
 ~~~~~~~~~~~~
 
-1.1.2 (unreleased)
+1.2.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Added `remove_properties` attribute to `Relationship` instantiation.  This allows a user to keep properties in both the parent and the child such as passing a parent's id to the child while keeping it in its properties.
+- Added `FilterRelationship` class which provides a shortcut to creating Relationships that point to a filtering against a list of resources.
 
 
 1.1.1 (2015-11-04)
 ==================
 
-- Nothing changed yet.
+- Moved up some imports for ease of use
 
 
 1.1.0 (2015-08-26)

--- a/docs/source/topics/relationships_and_links.rst
+++ b/docs/source/topics/relationships_and_links.rst
@@ -78,7 +78,7 @@ Cookbook
 
 .. testsetup:: queryargs, embedded, linktolist
 
-    from ripozo import ResourceBase, apimethod, Relationship, ListRelationship
+    from ripozo import ResourceBase, apimethod, Relationship, ListRelationship, FilteredRelationship
 
 A link with query args
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -213,7 +213,7 @@ If embedded was not equal to true we would only get the links to the resources i
     wanted to point to a location where you could explicitly get the children
     for a specific parent.  It's generally considered more RESTful to hit
     point to an endpoint like ``'/children?parent_id=1'`` than ``'/parent/1/children'``.
-    Fortunately this is extremely easy in ripozo.
+    Fortunately this is extremely easy in ripozo with the :class: `FilteredRelationship` class.
 
     *NOTE* If you are using a manager than you can use the ``restmixins.Retrieve`` and/or
     ``restmixins.RetrieveList`` instead of explicitly declaring the retrieve methods.
@@ -224,7 +224,7 @@ If embedded was not equal to true we would only get the links to the resources i
         class Parent(ResourceBase):
             pks = ('id',)
             relationships = (
-                Relationship('children', relation='Child', property_map=dict(id='parent_id'), no_pks=True, query_args=['parent_id']),
+                FilteredRelationship('children', relation='Child', property_map=dict(id='parent_id')),
             )
 
             @apimethod()

--- a/docs/source/topics/relationships_and_links.rst
+++ b/docs/source/topics/relationships_and_links.rst
@@ -262,3 +262,6 @@ Relationships API
 
 .. autoclass:: ripozo.resources.relationships.list_relationship.ListRelationship
     :members:
+
+.. autoclass:: ripozo.resources.relationships.relationship.FilteredRelationship
+    :members:

--- a/ripozo/__init__.py
+++ b/ripozo/__init__.py
@@ -7,7 +7,7 @@ any protocol.
 from ripozo.decorators import apimethod, translate
 from ripozo.resources import fields, restmixins
 from ripozo.resources.relationships.list_relationship import ListRelationship
-from ripozo.resources.relationships.relationship import Relationship
+from ripozo.resources.relationships.relationship import Relationship, FilteredRelationship
 from ripozo.resources.resource_base import ResourceBase
 from ripozo.resources.request import RequestContainer
 from ripozo.utilities import picky_processor

--- a/ripozo/resources/relationships/__init__.py
+++ b/ripozo/resources/relationships/__init__.py
@@ -8,4 +8,4 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from ripozo.resources.relationships.list_relationship import ListRelationship
-from ripozo.resources.relationships.relationship import Relationship
+from ripozo.resources.relationships.relationship import Relationship, FilteredRelationship

--- a/ripozo/resources/relationships/list_relationship.py
+++ b/ripozo/resources/relationships/list_relationship.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from ripozo.resources.relationships.relationship import Relationship
+from ripozo.utilities import get_or_pop
 
 
 class ListRelationship(Relationship):
@@ -30,28 +31,10 @@ class ListRelationship(Relationship):
         :return: A generator that yields the relationships.
         :rtype: types.GeneratorType
         """
-        objects = properties.pop(self.name, [])
-        objects = objects or []
+        objects = get_or_pop(properties, self.name, [], pop=self.remove_properties)
         resources = []
         for obj in objects:
             res = self.relation(properties=obj, query_args=self.query_args,
                                 include_relationships=self.embedded)
             resources.append(res)
         return resources
-
-    def remove_child_resource_properties(self, properties):
-        """
-        Removes the item from the properties dict with the key
-        that matches this instance's list_name attribute.  It
-        copies the properties and pops the property from the copy
-        before returning it.
-
-        :param dict properties: The properties with the list_name
-            key and value to be removed.
-        :return: The updated properties dict.  This is actually a copy
-            of the original to prevent side effects.
-        :rtype: dict
-        """
-        properties = properties.copy()
-        properties.pop(self.name, None)
-        return properties

--- a/ripozo/resources/relationships/relationship.py
+++ b/ripozo/resources/relationships/relationship.py
@@ -1,5 +1,6 @@
 """
-Contains the relationship class.
+Contains the relationship class and additional
+shortcut classes.
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/ripozo/utilities.py
+++ b/ripozo/utilities.py
@@ -154,3 +154,27 @@ def make_json_safe(obj):
     elif isinstance(obj, decimal.Decimal):
         obj = float(obj)
     return obj
+
+
+def get_or_pop(dictionary, key, default=None, pop=False):
+    """A simple helper for getting or popping a property
+    from a dictionary depending on the ```pop``` parameter.
+
+    This is a helper method for relationships to easily
+    update whether they keep or remove items from
+    the parent
+
+    :param dict dictionary: The dictionary to check
+    :param object key: The key to look for in the dictionary
+    :param object default: The default value to return if nothing
+        is found
+    :param bool pop: A boolean that removes the item from
+        the dictionary if true.  Otherwise it just gets
+        the value from the dictionary
+    :returns: The value of the requested object or the
+        default if it was not found.
+    :rtype: object
+    """
+    if pop:
+        return dictionary.pop(key, default)
+    return dictionary.get(key, default)

--- a/ripozo_tests/integration/relationships.py
+++ b/ripozo_tests/integration/relationships.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest2
+
+from ripozo.resources.relationships import Relationship, ListRelationship, FilteredRelationship
+from ripozo.resources.resource_base import ResourceBase
+
+
+class TestRelationships(unittest2.TestCase):
+    def test_link_to_list_of_child_resources(self):
+        """Tests whether there can be a relationship
+        That simply provides a link to a list of the children of
+        the resource.  In otherwords, they are not embedded in any
+        way.  Not even the child links"""
+        class Parent(ResourceBase):
+            pks = 'id',
+            _relationships = Relationship('children', relation='Child',
+                                          property_map=dict(id='parent_id'),
+                                          query_args=['parent_id'], no_pks=True,
+                                          remove_properties=False),
+
+        class Child(ResourceBase):
+            resource_name = 'child'
+            pks = 'id',
+
+        props = dict(id=1, name='something')
+        parent = Parent(properties=props)
+        link_to_children = parent.related_resources[0].resource
+        self.assertEqual(link_to_children.url, '/child?parent_id=1')
+        self.assertEqual(parent.url, '/parent/1')
+
+    def test_filter_relationship(self):
+        """Same as `test_link_to_list_of_children` but using the
+        `FilteredRelationship` class"""
+        class Parent(ResourceBase):
+            pks = 'id',
+            _relationships = FilteredRelationship('children', relation='Child',
+                                                  property_map=dict(id='parent_id')),
+
+        class Child(ResourceBase):
+            resource_name = 'child'
+            pks = 'id',
+
+        props = dict(id=1, name='something')
+        parent = Parent(properties=props)
+        link_to_children = parent.related_resources[0].resource
+        self.assertEqual(link_to_children.url, '/child?parent_id=1')
+        self.assertEqual(parent.url, '/parent/1')

--- a/ripozo_tests/unit/resources/relationships/relationship.py
+++ b/ripozo_tests/unit/resources/relationships/relationship.py
@@ -127,3 +127,34 @@ class TestRelationship(unittest2.TestCase):
         self.assertTrue(rel._should_return_none(res))
         rel.templated = True
         self.assertFalse(rel._should_return_none(res))
+
+    def test_remove_properties(self):
+        """Tests whether properties are appropriately
+        kept or removed according to the remove_properties
+        attribute"""
+        rel = Relationship('related')
+        x = dict(related=dict(name='name'))
+        ret = rel._map_pks(x)
+        self.assertDictEqual(ret, dict(name='name'))
+        self.assertDictEqual(x, dict())
+        rel.remove_properties = False
+        x = dict(related=dict(name='name'))
+        ret = rel._map_pks(x)
+        self.assertDictEqual(ret, dict(name='name'))
+        self.assertDictEqual(x, dict(related=dict(name='name')))
+
+    def test_remove_properties_property_map(self):
+        """Tests whether removing properties according
+        to the property_map adheres to the remove_properties
+        attribute"""
+
+        rel = Relationship('related', property_map=dict(name='name'))
+        x = dict(name='name')
+        ret = rel._map_pks(x)
+        self.assertDictEqual(ret, dict(name='name'))
+        self.assertDictEqual(x, dict())
+        rel.remove_properties = False
+        x = dict(name='name')
+        ret = rel._map_pks(x)
+        self.assertDictEqual(ret, dict(name='name'))
+        self.assertDictEqual(x, dict(name='name'))

--- a/ripozo_tests/unit/tests_utilities.py
+++ b/ripozo_tests/unit/tests_utilities.py
@@ -11,7 +11,7 @@ import six
 import unittest2
 
 from ripozo.utilities import titlize_endpoint, join_url_parts, \
-    picky_processor, convert_to_underscore, make_json_safe
+    picky_processor, convert_to_underscore, make_json_safe, get_or_pop
 
 
 class UtilitiesTestCase(unittest2.TestCase):
@@ -138,4 +138,30 @@ class UtilitiesTestCase(unittest2.TestCase):
         """joining parts when a single int.  Ensuring that it is unicode"""
         resp = join_url_parts(1)
         self.assertEqual(resp, '1')
+
+    def test_get_or_pop(self):
+        """Simple test to ensure that the get_or_pop
+        returns the value and appropriately updates the
+        dictionary if necessary"""
+        x = dict(x=1)
+        val = get_or_pop(x, 'x', pop=False)
+        self.assertDictEqual(x, dict(x=1))
+        self.assertEqual(val, 1)
+        val = get_or_pop(x, 'x', pop=True)
+        self.assertDictEqual(x, dict())
+        self.assertEqual(val, 1)
+
+    def test_get_or_pop_default(self):
+        """Ensures that a default is returned
+        if the key is not available"""
+        x = dict()
+        val = get_or_pop(x, 'x', pop=False)
+        self.assertIsNone(val)
+        val = get_or_pop(x, 'x', pop=True)
+        self.assertIsNone(val)
+        val = get_or_pop(x, 'x', default=1, pop=False)
+        self.assertEqual(val, 1)
+        val = get_or_pop(x, 'x', default=1, pop=True)
+        self.assertEqual(val, 1)
+
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 import os
 
-version = '1.1.2.dev0'
+version = '1.2.0.dev0'
 
 base_dir = os.path.dirname(__file__)
 


### PR DESCRIPTION
Allows a user to specify that a the properties of a relationship not be popped from the parent’s properties.  These are effectively shared resources (like pointing to parent’s ids)