### PR TITLE
Handle 204 "No Response" in all adapters.

### DIFF
--- a/ripozo/adapters/basic_json.py
+++ b/ripozo/adapters/basic_json.py
@@ -46,11 +46,17 @@ class BasicJSONAdapter(AdapterBase):
     @property
     def formatted_body(self):
         """
+        Gets the formatted body of the response in unicode form.
+        If ``self.status_code == 204`` then this will
+        return an empty string.
+
         :return: The formatted body that should be returned.
             It's just a ``json.dumps`` of the properties and
             relationships
         :rtype: unicode
         """
+        if self.status_code == 204:
+            return ''
         response = dict()
         parent_properties = self.resource.properties.copy()
         self._append_relationships_to_list(response, self.resource.related_resources)

--- a/ripozo/adapters/hal.py
+++ b/ripozo/adapters/hal.py
@@ -26,9 +26,15 @@ class HalAdapter(AdapterBase):
     @property
     def formatted_body(self):
         """
+        Gets the formatted body of the response in unicode form.
+        If ``self.status_code == 204`` then this will
+        return an empty string.
+
         :return: The response body for the resource.
         :rtype: unicode
         """
+        if self.status_code == 204:
+            return ''
         response = self._construct_resource(self.resource)
         return json.dumps(response)
 

--- a/ripozo/adapters/jsonapi.py
+++ b/ripozo/adapters/jsonapi.py
@@ -35,10 +35,14 @@ class JSONAPIAdapter(AdapterBase):
         """
         Returns a string in the
         `JSON API format. <http://jsonapi.org/format/>`_
+        If ``self.status_code == 204`` then this will
+        return an empty string.
 
         :return: The appropriately formatted string
         :rtype: unicode|str
         """
+        if self.status_code == 204:
+            return ''
         data = self._construct_data(self.resource, embedded=True)
         return json.dumps(dict(data=data))
 

--- a/ripozo_tests/unit/dispatch/adapters/boring_json.py
+++ b/ripozo_tests/unit/dispatch/adapters/boring_json.py
@@ -61,6 +61,18 @@ class TestBoringJSONAdapter(unittest2.TestCase):
         response = BasicJSONAdapter.format_request(request)
         self.assertIs(response, request)
 
+    def test_empty_response(self):
+        """
+        Tests whether an empty body is returned when the status_code
+        is 204
+        """
+        class MyResource(ResourceBase):
+            pass
+
+        res = MyResource(properties=dict(x='something'), status_code=204)
+        adapter = BasicJSONAdapter(res)
+        self.assertEqual(adapter.formatted_body, '')
+
     def test_append_relationships_to_list_list_relationship(self):
         """
         Tests whether the relationships are appropriately

--- a/ripozo_tests/unit/dispatch/adapters/hal.py
+++ b/ripozo_tests/unit/dispatch/adapters/hal.py
@@ -115,6 +115,17 @@ class TestHalAdapter(unittest2.TestCase):
         adapter = HalAdapter(None)
         self.assertEqual(adapter.extra_headers, {'Content-Type': 'application/hal+json'})
 
+    def test_empty_response(self):
+        """
+        Tests whether an empty body is returned when the status_code
+        is 204
+        """
+        class Fake(ResourceBase):
+            pass
+        res = Fake(properties=dict(x='something'), status_code=204)
+        adapter = HalAdapter(res)
+        self.assertEqual(adapter.formatted_body, '')
+
     def test_list_relationship_not_all_pks(self):
         class Fake(ResourceBase):
             pks = ['id']

--- a/ripozo_tests/unit/dispatch/adapters/jsonapi.py
+++ b/ripozo_tests/unit/dispatch/adapters/jsonapi.py
@@ -273,6 +273,18 @@ class TestJSONAPIAdapter(unittest2.TestCase):
         self.assertDictEqual(body['links'], dict(self='/my_resource/1'))
         self.assertDictEqual(body['attributes'], dict(id=1))
 
+    def test_empty_response(self):
+        """
+        Tests whether an empty body is returned when the status_code
+        is 204
+        """
+        class MyResource(ResourceBase):
+            pks = 'id',
+
+        res = MyResource(properties=dict(x='something'), status_code=204)
+        adapter = JSONAPIAdapter(res)
+        self.assertEqual(adapter.formatted_body, '')
+
     def test_no_pks_resource_construct_id(self):
         """
         Tests that a response is appropriately returned


### PR DESCRIPTION
Since all adapters should respond with an empty string in the case of a 204 status code, should this logic should be baked in to the base adapter? If so, how?

To meet my immediate need, I've applied the logic to each adapter.

Thanks!
