### PR TITLE
When returning a resource with no properties, use the 204 status code.

### DIFF
--- a/ripozo/resources/restmixins.py
+++ b/ripozo/resources/restmixins.py
@@ -272,7 +272,10 @@ class Delete(ResourceBase):
         """
         _logger.debug('Deleting the resource using manager %s ', cls.manager)
         props = cls.manager.delete(request.url_params)
-        return cls(properties=props)
+        if props:
+            return cls(properties=props)
+        else:
+            return cls(status_code=204, properties=props)
 
 
 class RetrieveUpdate(Retrieve, Update):

--- a/ripozo_tests/integration/restmixins.py
+++ b/ripozo_tests/integration/restmixins.py
@@ -265,6 +265,7 @@ class TestDelete(TestBase):
         req = RequestContainer(url_params=dict(id=id_), body_args=dict(first=2))
         resource = self.resource_class.delete(req)
         self.assertDictEqual(resource.properties, {})
+        self.assertEqual(resource.status_code, 204)
         self.assertNotIn(id_, self.manager.objects)
 
     def test_delete_manager_fields(self):


### PR DESCRIPTION
Some managers (AlchemyManager for instance) return an empty dict on `delete()`. Along with #60, this change facilitates an empty response when deleting a resource.