### PR TITLE
Include LICENSE.txt in the tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include CHANGELOG.rst
+include LICENSE.txt


### PR DESCRIPTION
The text of license shall be distributed with sources:

> You should have received a copy of the GNU General Public License along with this program;